### PR TITLE
Fix all contacts showing when no match; create chips with space

### DIFF
--- a/library/chips/src/com/android/ex/chips/BaseRecipientAdapter.java
+++ b/library/chips/src/com/android/ex/chips/BaseRecipientAdapter.java
@@ -232,7 +232,7 @@ public class BaseRecipientAdapter extends BaseAdapter implements Filterable, Acc
             }
 
             if (constraint == null) {
-                constraint = "Choose Contacts:";
+                return new FilterResults();
             }
 
             final FilterResults results = new FilterResults();
@@ -240,9 +240,8 @@ public class BaseRecipientAdapter extends BaseAdapter implements Filterable, Acc
             Cursor directoryCursor = null;
             boolean limitResults = true;
 
-            if (constraint.equals("Choose Contacts:")) {
+            if (TextUtils.isEmpty(constraint)) {
                 limitResults = false;
-                constraint = " ";
             }
 
             try {

--- a/library/chips/src/com/android/ex/chips/RecipientEditTextView.java
+++ b/library/chips/src/com/android/ex/chips/RecipientEditTextView.java
@@ -1409,6 +1409,10 @@ public class RecipientEditTextView extends MultiAutoCompleteTextView implements
      */
     @Override
     protected void performFiltering(CharSequence text, int keyCode) {
+        if (TextUtils.isEmpty(text)) {
+            getFilter().filter("", this);
+            return;
+        }
         boolean isCompletedToken = isCompletedToken(text);
         if (enoughToFilter() && !isCompletedToken) {
             int end = getSelectionEnd();
@@ -2296,7 +2300,6 @@ public class RecipientEditTextView extends MultiAutoCompleteTextView implements
     }
 
     public void showAllContacts() {
-        setThreshold(0);
         dismissDropDownOnItemSelected(false);
         getHandler().postDelayed(new Runnable() {
             @Override
@@ -2304,6 +2307,7 @@ public class RecipientEditTextView extends MultiAutoCompleteTextView implements
                 setTextColor(getCurrentHintTextColor());
                 setText("Choose Contacts:");
                 setSelection(16);
+                performFiltering("", 0);
             }
         }, 500);
     }

--- a/library/chips/src/com/android/ex/chips/RecipientEditTextView.java
+++ b/library/chips/src/com/android/ex/chips/RecipientEditTextView.java
@@ -2430,7 +2430,7 @@ public class RecipientEditTextView extends MultiAutoCompleteTextView implements
         } else {
             last = s.charAt(len);
         }
-        return last == COMMIT_CHAR_COMMA || last == COMMIT_CHAR_SEMICOLON;
+        return last == COMMIT_CHAR_COMMA || last == COMMIT_CHAR_SEMICOLON || last == COMMIT_CHAR_SPACE;
     }
 
     public boolean isGeneratedContact(DrawableRecipientChip chip) {


### PR DESCRIPTION
Two improvements for email:
1. Fix the issue where all contacts are showing when you enter two characters and there is no match
2. Allow using spaces to create chips (using @tyczj's solution in https://github.com/klinker41/android-chips/issues/5)