### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ Usage is extremely simple:
 final RecipientEditTextView phoneRetv =
         (RecipientEditTextView) findViewById(R.id.phone_retv);
 phoneRetv.setTokenizer(new MultiAutoCompleteTextView.CommaTokenizer());
-phoneRetv.setAdapter(new BaseRecipientAdapter(BaseRecipientAdapter.QUERY_TYPE_PHONE, this));
+BaseRecipientAdapter baseRecipientAdapter = new BaseRecipientAdapter(BaseRecipientAdapter.QUERY_TYPE_PHONE, this);
+
+// Queries for all phone numbers. Includes phone numbers marked as "mobile" and "others".
+// If set as true, baseRecipientAdapter will query only for phone numbers marked as "mobile".  
+baseRecipientAdapter.setShowMobileOnly(false);
+
+phoneRetv.setAdapter(baseRecipientAdapter);
+
+
 ```
 
 OR


### PR DESCRIPTION
I spent quite a lot of time in figuring out why the baseRecipientAdapter couldn't query for all phone numbers in my contact list. It turned out that by default the adapter only queries for phone numbers which are marked as "mobile".

```
baseRecipientAdapter.setShowMobileOnly(false);
```

Adding this lets the adapter query for all phone numbers. 
