### PR TITLE
Fix style reference which aapt2 does not accept

### DIFF
--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -15,7 +15,7 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools"
            xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <style name="RecipientEditTextView" parent="@android:attr/autoCompleteTextViewStyle">
+    <style name="RecipientEditTextView" parent="@android:style/Widget.AutoCompleteTextView">
         <item name="android:inputType">textEmailAddress|textMultiLine</item>
         <item name="android:imeOptions">actionNext|flagNoFullscreen</item>
         <item name="android:textAppearance">?android:attr/textAppearanceMedium</item>


### PR DESCRIPTION
This aims to solve #50 by properly referencing the style, PTAL. Note: I've verified this compiles but haven't double checked that the in-app behavior is exactly as expected (although I'd guess it would be). It would be great if someone could verify that it works properly.